### PR TITLE
fix(home-page): typo in Fournier bio heading

### DIFF
--- a/pyconca2017/locale/fr/LC_MESSAGES/django.po
+++ b/pyconca2017/locale/fr/LC_MESSAGES/django.po
@@ -533,7 +533,7 @@ msgstr ""
 "        "
 
 #: pyconca2017/templates/pages/home.html:99
-msgid "Managing Directory and Head of Platform Engineering"
+msgid "Managing Director and Head of Platform Engineering"
 msgstr ""
 
 #: pyconca2017/templates/pages/home.html:101

--- a/pyconca2017/templates/pages/home.html
+++ b/pyconca2017/templates/pages/home.html
@@ -96,7 +96,7 @@
       </div>
       <div class="col-md-6 c-block-keynote__left">
         <h1 class="c-block-keynote__heading">Camille Fournier</h1>
-        <h3>{% trans "Managing Directory and Head of Platform Engineering" %}</h3>
+        <h3>{% trans "Managing Director and Head of Platform Engineering" %}</h3>
         <p>
           {% blocktrans %}
             Camille Fournier is a Managing Director and Head of Platform Engineering at Two Sigma.  She is the former


### PR DESCRIPTION
Address a typo in the keynote bio header. I'm not sure what the process around translations would be. Are these all the changes that are necessary?